### PR TITLE
Add missing dep in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "thecodingmachine/safe": "^3.3"
     },
     "require-dev": {
         "driftingly/rector-laravel": "^2.0.5",


### PR DESCRIPTION
After fresh install of this package via: `composer require` it throws an error:

`Call to undefined function Safe\preg_split()`

As I've found out, you are using this package, but it is not defined in composer.json as a dependency:

`thecodingmachine/safe`

I've tried to add it manually to my composer and now it works. But it should be in your package explicitly defined as dependency to prevent these kind of errors.

So I'm pushing this as PR to your repo to fix it directly.